### PR TITLE
Make TTL config value to be in minutes instead of seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ a standard tmux message with additional weather details:
 ### Time-to-live (TTL)
 
 This plugin caches the weather by default for 15 minutes. You can set any other
-TTL value (in seconds) using the option:
+TTL value (in minutes) using the option:
 
 ```bash
-set -g @clima_ttl <value_in_seconds>
+set -g @clima_ttl <value_in_minutes>
 ```
 
 ### Unit

--- a/scripts/clima.sh
+++ b/scripts/clima.sh
@@ -6,7 +6,7 @@ source "$CWD/icons.sh"
 
 # Weather data reference: http://openweathermap.org/weather-conditions
 
-TTL=$(get_tmux_option @clima_ttl 900)
+TTL=$((60 * $(get_tmux_option @clima_ttl 15)))
 UNIT=$(get_tmux_option @clima_unit "metric")
 SHOW_ICON=$(get_tmux_option @clima_show_icon 1)
 SHOW_LOCATION=$(get_tmux_option @clima_show_location 1)


### PR DESCRIPTION
This is to make it easier for user and get the conversion calculation done in script.