### PR TITLE
Remove space between icon and temp and delete an extra space in an icon

### DIFF
--- a/scripts/clima.sh
+++ b/scripts/clima.sh
@@ -69,7 +69,7 @@ clima() {
                 CLIMA="$CLIMA$ICON"
             fi
 
-            CLIMA="$CLIMA $TEMP"
+            CLIMA="$CLIMA$TEMP"
             CLIMA_DETAILS="${CITY}, ${COUNTRY}: ${ICON} ${TEMP}, ${DESCRIPTION}, ${FEELS_LIKE}, ${WIND_SPEED}"
 
             set_tmux_option "@clima_last_update_time" "$NOW"

--- a/scripts/icons.sh
+++ b/scripts/icons.sh
@@ -49,7 +49,7 @@ icon() {
             ;;
             # Atmosphere group
         701 | 711 | 721 | 731 | 751 | 761 | 762 | 771)
-            [[ $NERD_FONT == 1 ]] && echo ' ' || echo '  '
+            [[ $NERD_FONT == 1 ]] && echo ' ' || echo ' '
             ;;
         741)
             [[ $NERD_FONT == 1 ]] && echo ' ' || echo '🌫 '


### PR DESCRIPTION
Since all icons are two characters long, so there's an intrinsic space between itself and the next character/item.